### PR TITLE
multiclass predict and bugfixes

### DIFF
--- a/clamsa.py
+++ b/clamsa.py
@@ -431,7 +431,7 @@ Use one of the following commands:
 
         parser.add_argument('input', 
                             metavar='INPUT',
-                            help='A space separated list of paths to text files containing themselves paths to MSA files of the chosen input type.\nEach MSA file contains a single alignment.',
+                            help='If INPUT_TYPE == fasta: A space separated list of paths to text files containing themselves paths to MSA files.\nEach MSA file contains a single alignment.\nIf INPUT_TYPE == tfrecord: A space separated list of paths to tfrecord files.',
                             type=file_exists,
                             nargs='+',
         )

--- a/clamsa.py
+++ b/clamsa.py
@@ -571,7 +571,8 @@ dm3.chr1 dmel''',
                                               tuple_length = args.tuple_length,
                                               batch_size = args.batch_size,
                                               trans_dict = trans_dict,
-                                              remove_stop_rows = args.remove_stop_rows
+                                              remove_stop_rows = args.remove_stop_rows,
+                                              num_classes = args.num_classes
             )
 
         if args.in_type == 'tfrecord':


### PR DESCRIPTION
- fixed class output bug in predict_on_tfrecords() that occurs if you predict more than 2 classes
- added functionality to predict more than 2 classes on fasta & tfrecord files
- fixed help for INPUT argument